### PR TITLE
Added the reactive feat(useMount)(): new function composable

### DIFF
--- a/src/composables/useMount/index.md
+++ b/src/composables/useMount/index.md
@@ -1,0 +1,46 @@
+---
+category: Integration
+---
+
+# useMount
+
+Reactive Planewave API mount client.
+
+## Usage
+
+```ts
+import { ref, watch } from 'vue'
+
+import { useMount } from '@observerly/useaestrium
+
+const ra = ref(0)
+
+const dec = ref(0)
+
+const { connect, disconnect, goToEquatorialCoordinate } = useMount({
+  url: 'http://127.0.0.1:5000',
+  immediate: true
+})
+
+// async watch for a change in the ra or dec position to slew the mount to the EquatorialCoordinate:
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+watch([ra, dec], async ([prevRA, prevdec], [newRA, newdec]) => {
+  if (prevRA !== newRA || prevdec !== newdec) {
+    const status = await goToEquatorialCoordinate({ ra: ra.value, dec: dec.value })
+  }
+})
+```
+
+See the [Type Declarations](#type-declarations) for more options.
+
+### Immediate
+
+Auto-connect (enabled by default) onMounted lifecycle hook.
+
+This will call `connect()` automatically for you and you don't need to call it by yourself.
+
+### Auto-disconnect
+
+Auto-close-connection (enabled by default) onUnmounted lifecycle hook.
+
+This will call `disconnect()` automatically when the component unmounts.

--- a/src/composables/useMount/index.ts
+++ b/src/composables/useMount/index.ts
@@ -1,0 +1,91 @@
+import {
+  onMounted, onUnmounted
+} from 'vue'
+
+import {
+  EquatorialCoordinate, convertDegreesToHours
+} from '@observerly/celestia'
+
+export interface UseMountOptions {
+  /**
+   *
+   * URL/ip:port/host to the remote observatory NAT
+   * @default 'http://0.0.0.0:8220'
+   */
+  url: string
+  /**
+   *
+   * Immediately Connect to the Mount (optional)
+   * @default true
+   */
+  immediate?: boolean
+}
+
+// The namespace for the Planewave API endpoint construction:
+const namespace = 'mount'
+
+// Default mount options:
+const defaultMountOptions = {
+  url: 'http://0.0.0.0:8220',
+  immediate: true
+}
+
+/**
+ * Reactive useMount()
+ * Returns a reactive PlaneWave telescope mount instance via the PlanewaveAPI
+ *
+ * @param options of type UseMountOptions
+ * @output calls connect() immediately onMounted Vue lifecycle hook.
+ * @returns mount connect method(), mount disconnect() method and goToEquatorialCoordinate().
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const useMount = (options: UseMountOptions = defaultMountOptions) => {
+  const { url, immediate = true } = options
+
+  const connect = async () => {
+    await fetch(`${url}/${namespace}/connect`)
+  }
+
+  const disconnect = async () => {
+    await fetch(`${url}/${namespace}/disconnect`)
+  }
+
+  const goToEquatorialCoordinate = async (params: EquatorialCoordinate) => {
+    const { ra, dec } = params
+
+    const ha = convertDegreesToHours(ra)
+
+    const uri: URL = new URL(`${url}/${namespace}/goto/coordinates/equatorial`)
+
+    uri.searchParams.append('ra_hours', ha.toString())
+
+    uri.searchParams.append('dec_degs', dec.toString())
+
+    const response = await fetch(uri.toString(), {
+      method: 'GET', // *GET, POST, PUT, DELETE, etc.
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    })
+
+    return response.json()
+  }
+
+  onMounted(() => {
+    if (immediate) {
+      connect()
+    }
+  })
+
+  onUnmounted(() => {
+    disconnect()
+  })
+
+  return {
+    connect,
+    disconnect,
+    goToEquatorialCoordinate
+  }
+}
+
+export type UseMountReturn = ReturnType<typeof useMount>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export {
+  useMount
+} from '@/composables/useMount'


### PR DESCRIPTION
Added the reactive useMount() composable for a PlaneWave telescope mount instance via the Planewave HTTP API.

Added the base useMount() composable to base exports. 

Added index.md for usage documentation.