### PR TITLE
Defined UseMountProps interface that is an optional version of the UseMountReturn type. Added UseMountOptions, UseMountReturn and UseMountProps.

### DIFF
--- a/src/composables/useMount/index.ts
+++ b/src/composables/useMount/index.ts
@@ -42,11 +42,11 @@ const defaultMountOptions = {
 export const useMount = (options: UseMountOptions = defaultMountOptions) => {
   const { url, immediate = true } = options
 
-  const connect = async () => {
+  const connect = async (): Promise<void> => {
     await fetch(`${url}/${namespace}/connect`)
   }
 
-  const disconnect = async () => {
+  const disconnect = async (): Promise<void> => {
     await fetch(`${url}/${namespace}/disconnect`)
   }
 
@@ -89,3 +89,9 @@ export const useMount = (options: UseMountOptions = defaultMountOptions) => {
 }
 
 export type UseMountReturn = ReturnType<typeof useMount>
+
+export interface UseMountProps {
+  connect?: () => Promise<void>
+  disconnect?: () => Promise<void>
+  goToEquatorialCoordinate?: () => Promise<any>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 export {
-  useMount
+  useMount,
+  UseMountOptions,
+  UseMountReturn,
+  UseMountProps
 } from './composables/useMount'


### PR DESCRIPTION
Defined UseMountProps interface that is an optional version of the UseMountReturn type. 

Added UseMountOptions, UseMountReturn and UseMountProps to the list of exports from './composables/useMount'.