### PR TITLE
Added (params: EquatorialCoordinate) declaration to the goToEquatorialCoordinate type in UseMountProps.

### DIFF
--- a/src/composables/useMount/index.ts
+++ b/src/composables/useMount/index.ts
@@ -93,5 +93,5 @@ export type UseMountReturn = ReturnType<typeof useMount>
 export interface UseMountProps {
   connect?: () => Promise<void>
   disconnect?: () => Promise<void>
-  goToEquatorialCoordinate?: () => Promise<any>
+  goToEquatorialCoordinate?: (params: EquatorialCoordinate) => Promise<any>
 }


### PR DESCRIPTION
[Bug Fix] Added (params: EquatorialCoordinate) declaration to the goToEquatorialCoordinate type in UseMountProps.