### PR TITLE
Minor change to the naming conventions applied to useFocuser() goToFocusTarget() method call.

### DIFF
--- a/src/composables/useFocuser/index.md
+++ b/src/composables/useFocuser/index.md
@@ -15,7 +15,7 @@ import { useFocuser } from '@observerly/useaestrium
 
 const target = ref('')
 
-const { goToFocuserTarget } = useMount({
+const { goToFocusTarget } = useMount({
   url: 'http://127.0.0.1:5000',
   immediate: true
 })
@@ -24,7 +24,7 @@ const { goToFocuserTarget } = useMount({
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 watch(target, async (prevTarget, newTarget) => {
   if (prevTarget !== newTarget) {
-    const status = await goToFocuserTarget({ target: target.value })
+    const status = await goToFocusTarget({ target: target.value })
   }
 })
 ```

--- a/src/composables/useFocuser/index.ts
+++ b/src/composables/useFocuser/index.ts
@@ -28,7 +28,7 @@ export interface UseFocuserOptions {
 export type UseFocuserReturn = {
   enable: () => Promise<void>
   disable: () => Promise<void>
-  goToFocuserTarget: (params: FocuserTargetParams) => Promise<UseStatusResponse>
+  goToFocusTarget: (params: FocuserTargetParams) => Promise<UseStatusResponse>
   stop: () => Promise<void>
 }
 
@@ -58,10 +58,10 @@ export const useFocuser = (options: UseFocuserOptions = defaultFocuserOptions): 
     await fetch(`${baseURL}/disable`)
   }
 
-  const goToFocuserTarget = async (
+  const goToFocusTarget = async (
     params: FocuserTargetParams
   ): Promise<UseStatusResponse> => {
-    const uri: URL = new URL(`${baseURL}/goto`)
+    const uri: URL = new URL(`${baseURL}/goto/focus/target`)
 
     uri.searchParams.append('target', params.target)
 
@@ -93,7 +93,7 @@ export const useFocuser = (options: UseFocuserOptions = defaultFocuserOptions): 
   return {
     enable,
     disable,
-    goToFocuserTarget,
+    goToFocusTarget,
     stop
   }
 }


### PR DESCRIPTION
Minor change to the naming conventions applied to useFocuser() goToFocusTarget() method call.