### PR TITLE
Added the useEquatorialCoordinate() composable.

### DIFF
--- a/src/composables/useEquatorialCoordinate/index.md
+++ b/src/composables/useEquatorialCoordinate/index.md
@@ -1,0 +1,41 @@
+---
+category: Sensors
+---
+
+# useEquatorialCoordinate
+
+Reactive equatorial coordinate
+
+## Usage
+
+```ts
+import { ref } from 'vue'
+
+import { useEquatorialCoordinate } from '@observerly/useaestrium
+
+// Define a star at a known Equatorial Coordinate (e.g., Betelgeuse):
+const betelgeuse = {
+  ra: 88.7929583,
+  dec: 7.4070639
+}
+
+// Provide the observer, which is a longitude and latitude value, 
+// for example purposes this has been chosen as Manua Kea, Hawaii, US
+const observer = ref({
+  latitude: 19.820611,
+  longitude: -155.468094,
+  elevation: 0
+})
+
+// We need to specify a date because most calculations are
+// differential w.r.t a time component:
+const datetime = ref(new Date('2021-05-14T00:00:00.000+00:00'))
+
+const { alt, az } = useEquatorialCoordinate({
+  coordinate: betelgeuse,
+  observer,
+  datetime
+})
+```
+
+See the [Type Declarations](#type-declarations) for more options.

--- a/src/composables/useEquatorialCoordinate/index.test.ts
+++ b/src/composables/useEquatorialCoordinate/index.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+  describe,
+  expect,
+  it
+} from '@jest/globals'
+
+import {
+  ref
+} from 'vue'
+
+import {
+  useEquatorialCoordinate
+} from './'
+
+import {
+  useSetup
+} from '../../utils'
+
+describe('useEquatorialCoordinate', () => {
+  it('Should Be Defined', () => {
+    expect(useEquatorialCoordinate).toBeDefined()
+  })
+
+  it('Betelgeuse Should Be ', () => {
+    useSetup(() => {
+      // Define a star at a known Equatorial Coordinate:
+      const betelgeuse = {
+        ra: 88.7929583,
+        dec: 7.4070639
+      }
+
+      //  For testing, we will fix the longitude and latitude to be Manua Kea, Hawaii, US
+      const observer = ref({
+        latitude: 19.820611,
+        longitude: -155.468094,
+        elevation: 0
+      })
+
+      // For testing we need to specify a date because most calculations are
+      // differential w.r.t a time component. We set it to the author's birthday:
+      const datetime = ref(new Date('2021-05-14T00:00:00.000+00:00'))
+
+      const { alt, az } = useEquatorialCoordinate({
+        coordinate: betelgeuse,
+        observer,
+        datetime
+      })
+
+      expect(alt.value).toBeCloseTo(72.78539444063765, 1)
+      expect(az.value).toBeCloseTo(134.44877920325155, 1)
+    })
+  })
+})

--- a/src/composables/useEquatorialCoordinate/index.ts
+++ b/src/composables/useEquatorialCoordinate/index.ts
@@ -1,0 +1,125 @@
+import {
+  readonly,
+  ref,
+  watchEffect
+} from 'vue'
+
+import type {
+  Ref
+} from 'vue'
+
+import {
+  convertEquatorialToHorizontal
+} from '@observerly/celestia'
+
+import type {
+  HorizontalCoordinate,
+  EquatorialCoordinate
+} from '@observerly/celestia'
+
+export interface Observer {
+  /**
+   *
+   * Geographic longitude of the observer (in unit degree)
+   * @default -22.95764
+   *
+   */
+  longitude: number
+  /**
+   *
+   * Geographic latitude of the observer (in unit degree)
+   * @default 18.49041
+   *
+   */
+  latitude: number
+  /**
+   *
+   * Elevation (above sea level) of the observer (in unit meteres)
+   * @default 0
+   *
+   */
+  elevation: number
+}
+
+export interface UseEquatorialCoordinateOptions {
+  /**
+   *
+   * Coordinate { ra, dec } of the observed celestial target:
+   *
+   */
+  coordinate: EquatorialCoordinate
+  /**
+   *
+   * A datetime reference:
+   *
+   */
+  datetime: Ref<Date>
+  /**
+   *
+   * An observer object reference:
+   *
+   */
+  observer: Ref<Observer>
+}
+
+type RefKeys<T, K extends keyof T = keyof T> = {
+  // eslint-disable-next-line no-unused-vars
+  [key in K]: Ref<T[K]>
+}
+
+export interface UseEquatorialCoordinateReturn extends RefKeys<EquatorialCoordinate & HorizontalCoordinate> {}
+
+export interface UseEquatorialCoordinateProps extends Partial<UseEquatorialCoordinateReturn> {}
+
+// Set the default observer to Namibia:
+const defaultObserver = {
+  longitude: -22.95764,
+  latitude: 18.49041,
+  elevation: 0
+}
+
+/**
+ *
+ * reactive useEquatorialCoordinate()
+ *
+ * @param options
+ * @returns UseEquatorialCoordinateReturn { ra, dec, alt, az }
+ */
+export const useEquatorialCoordinate = (
+  options: UseEquatorialCoordinateOptions
+): UseEquatorialCoordinateReturn => {
+  const {
+    coordinate,
+    datetime,
+    observer = ref(defaultObserver)
+  } = options
+
+  const ra = ref(coordinate.ra)
+
+  const dec = ref(coordinate.dec)
+
+  const alt = ref(Infinity)
+
+  const az = ref(Infinity)
+
+  watchEffect(() => {
+    const { alt: altitude, az: azimuth } = convertEquatorialToHorizontal(
+      {
+        ra: ra.value,
+        dec: dec.value
+      },
+      observer.value,
+      datetime.value
+    )
+
+    alt.value = altitude
+    az.value = azimuth
+  })
+
+  return {
+    ra,
+    dec,
+    alt: readonly(alt),
+    az: readonly(az)
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
 export {
+  useEquatorialCoordinate,
+  UseEquatorialCoordinateOptions,
+  UseEquatorialCoordinateReturn,
+  UseEquatorialCoordinateProps
+} from './composables/useEquatorialCoordinate'
+
+export {
   useMount,
   UseMountOptions,
   UseMountReturn,


### PR DESCRIPTION
Added the useEquatorialCoordinate() composable which converts { ra, dec } to alt and az via the watchEffect() which runs immediately while reactively tracking the relative dependencies and re-runs it whenever the dependencies are changed (i.e., the observer and datetime refs).

Includes associated test suite and usage examples.