### PR TITLE
Added the useInternalClock() composable to the module exports.

### DIFF
--- a/src/composables/useInternalClock/index.ts
+++ b/src/composables/useInternalClock/index.ts
@@ -6,7 +6,7 @@ import {
   onKeyStroke, useIntervalFn
 } from '@vueuse/core'
 
-interface UseInternalClockOptions {
+export interface UseInternalClockOptions {
   /**
    *
    * clock starting datetime:

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,13 @@ export {
 } from './composables/useEquatorialCoordinate'
 
 export {
+  useInternalClock,
+  UseInternalClockOptions,
+  UseInternalClockReturn,
+  UseInternalClockProps
+} from './composables/useInternalClock'
+
+export {
   useMount,
   UseMountOptions,
   UseMountReturn,


### PR DESCRIPTION
Added the useInternalClock() composable to the module exports. Includes explicitly exporting the UseInternalClockOptions from the composable.