### PR TITLE
[Bugfix] Potential hosted refs bug within the useObserver() composable.

### DIFF
--- a/src/composables/useObserver/index.ts
+++ b/src/composables/useObserver/index.ts
@@ -26,9 +26,6 @@ export const validateLongitude = (longitude: number): boolean => {
   return (isFinite(longitude) && Math.abs(longitude) <= 180 && Math.abs(longitude) >= -180) || false
 }
 
-// Obtain the querystring params of the url, if any:
-const params = useUrlSearchParams('history')
-
 export interface Observer {
   /**
    *
@@ -71,6 +68,9 @@ export const useObserver = (options: UseObserverOptions) => {
     latitude: lat = defaultObserver.latitude,
     elevation: ele = defaultObserver.elevation
   } = options
+
+  // Obtain the querystring params of the url, if any:
+  const params = useUrlSearchParams('history')
 
   // Reactive Geolocation API. It allows the user to provide their location
   // to web applications if they so desire. For privacy reasons, the user is

--- a/vite.lib.config.ts
+++ b/vite.lib.config.ts
@@ -28,6 +28,17 @@ export default defineConfig({
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'useaestrium',
       fileName: format => `useaestrium.${format}.js`
+    },
+    rollupOptions: {
+      external: ['vue', '@observerly/celestia'],
+      output: {
+        sourcemap: false,
+        // Provide global variables to use in the UMD build
+        // for externalized deps
+        globals: {
+          vue: 'Vue'
+        }
+      }
     }
   }
 })


### PR DESCRIPTION
[Bugfix] Potential hosted refs bug within the useObserver() composable. Includes added rollupOptions in vite.lib.config.ts.